### PR TITLE
Feat/tool drug interactions

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,4 +1,4 @@
 {
-    "python-envs.defaultEnvManager": "ms-python.python:poetry",
-    "python-envs.defaultPackageManager": "ms-python.python:poetry"
+    "python-envs.defaultEnvManager": "ms-python.python:pyenv",
+    "python-envs.defaultPackageManager": "ms-python.python:pip"
 }

--- a/backend/app/core/bot.py
+++ b/backend/app/core/bot.py
@@ -10,7 +10,7 @@ from langchain_core.prompts import PromptTemplate
 from langchain_core.vectorstores import VectorStore
 from langchain_core.messages import BaseMessageChunk, message_to_dict
 from langchain_qdrant import QdrantVectorStore
-from langchain.agents import AgentExecutor, create_openai_functions_agent
+from langchain_classic.agents import AgentExecutor, create_openai_functions_agent
 
 from app.core.config import settings
 from app.core.tools import DRUG_TOOLS

--- a/backend/app/core/bot.py
+++ b/backend/app/core/bot.py
@@ -1,5 +1,6 @@
 import json
 import os
+import re
 from pydantic import BaseModel
 from typing import List, Dict, Optional
 
@@ -9,8 +10,10 @@ from langchain_core.prompts import PromptTemplate
 from langchain_core.vectorstores import VectorStore
 from langchain_core.messages import BaseMessageChunk, message_to_dict
 from langchain_qdrant import QdrantVectorStore
+from langchain.agents import AgentExecutor, create_openai_functions_agent
 
 from app.core.config import settings
+from app.core.tools import DRUG_TOOLS
 
 
 LLM = init_chat_model(
@@ -111,6 +114,150 @@ def retrieve_and_generate(prompt, tenant=None):
 
 
 def retrieve_and_generate_sync(prompt, tenant=None):
+    state = {'question': prompt, 'context': None, 'answer': ''}
+    if tenant:
+        state.update({'tenant': tenant})
+
+    context = retrieve(VECTOR_STORE, state)
+    state['context'] = context['context']
+
+    message = generate_sync(state)
+    return message
+
+
+AGENT_SYSTEM_PROMPT = """You are a medical assistant. Your job is to help users with medication-related questions.
+
+You have access to the following tools:
+- check_drug_interactions: Check for interactions between multiple medications
+- get_drug_info: Get detailed information about a single drug
+
+When a user asks about:
+- Drug interactions (e.g., "Can I take X with Y?")
+- Taking multiple medications together
+- Safety of combining drugs
+
+You MUST use the check_drug_interactions tool.
+
+When a user asks about:
+- What a drug is used for
+- Side effects of a drug
+- General information about a medication
+
+You should use the get_drug_info tool.
+
+If the question is about general medical topics (not specific drugs), use the provided context to answer.
+
+Always prioritize patient safety - if unsure, recommend consulting a healthcare professional.
+"""
+
+DRUG_INTERACTION_PATTERNS = [
+    r"\b(can i take|can i take|can\s+.*take|taking.*with|interact|interaction)",
+    r"\b(together|combine|with|while on|on medication)",
+    r"\b(drug|drugs|medication|medicine|pill)",
+]
+
+DRUG_KEYWORDS = [
+    "warfarin", "aspirin", "ibuprofen", "acetaminophen", " Tylenol ",
+    "lipitor", "zoloft", "metformin", "amoxicillin", "prednisone",
+    "lisinopril", "metoprolol", "omeprazole", "amlodipine", "losartan",
+    "xanax", "valium", "ambien", "prozac", "neurontin", "lyrica",
+    "coumadin", "heparin", "plavix", "eliquis", "xarelto",
+    "zocor", "crestor", "effexor", "celexa", "lexapro",
+]
+
+
+def is_drug_interaction_query(prompt: str) -> bool:
+    """Detect if the prompt is asking about drug interactions."""
+    prompt_lower = prompt.lower()
+    
+    if any(kw in prompt_lower for kw in DRUG_KEYWORDS):
+        if any(re.search(pattern, prompt_lower) for pattern in DRUG_INTERACTION_PATTERNS):
+            return True
+    
+    interaction_phrases = [
+        "interact", "interaction", "can i take", "taking together",
+        "combine", "safe to take", "side effects", "with warfarin",
+        "with aspirin", "with ibuprofen", "with acetaminophen",
+    ]
+    return any(phrase in prompt_lower for phrase in interaction_phrases)
+
+
+def get_drug_names(prompt: str) -> List[str]:
+    """Extract potential drug names from the prompt."""
+    prompt_lower = prompt.lower()
+    found_drugs = []
+    
+    common_drugs = [
+        "warfarin", "coumadin", "aspirin", "ibuprofen", "advil", "motrin",
+        "acetaminophen", "tylenol", "naproxen", "aleve", "meloxicam",
+        "diclofenac", "celecoxib", "prednisone", "methylprednisolone",
+        "heparin", "enoxaparin", "plavix", "clopidogrel", "prasugrel",
+        "apixaban", "rivaroxaban", "dabigatran", "eliquis", "xarelto",
+        "lipitor", "atorvastatin", "simvastatin", "zocor", "rosuvastatin",
+        "zoloft", "sertraline", "fluoxetine", "prozac", "paroxetine",
+        "paxil", "citalopram", "escitalopram", "lexapro", "effexor",
+        "venlafaxine", "duloxetine", "cymbalta", "metformin", "glipizide",
+        "glyburide", "insulin", "lisinopril", "losartan", "valsartan",
+        "atenolol", "metoprolol", "propranolol", "carvedilol", "amlodipine",
+        "diltiazem", "verapamil", "omeprazole", "pantoprazole", "esomeprazole",
+        "nexium", "prilosec", "xanax", "alprazolam", "lorazepam",
+        "ativan", "valium", "diazepam", "klonopin", "clonazepam",
+        "ambien", "zolpidem", "lunesta", "eszopiclone", "benadryl",
+        "diphenhydramine", "zyrtec", "claritin", "allegra", "advair",
+        "symbicort", "albuterol", "ventolin", "prednisone", "medrol",
+    ]
+    
+    for drug in common_drugs:
+        if drug in prompt_lower:
+            found_drugs.append(drug.title())
+    
+    return found_drugs
+
+
+def create_agent():
+    """Create a LangChain agent with drug interaction tools."""
+    prompt = PromptTemplate.from_template("{input}\n\n{agent_scratchpad}")
+    
+    agent = create_openai_functions_agent(
+        llm=LLM,
+        tools=DRUG_TOOLS,
+        prompt=prompt
+    )
+    
+    agent_executor = AgentExecutor(
+        agent=agent,
+        tools=DRUG_TOOLS,
+        verbose=True,
+        max_iterations=5,
+        handle_parsing_errors=True
+    )
+    
+    return agent_executor
+
+
+AGENT_EXECUTOR = create_agent()
+
+
+def process_with_tools(prompt: str) -> str:
+    """Process a prompt using the agent with drug interaction tools."""
+    try:
+        result = AGENT_EXECUTOR.invoke({"input": prompt})
+        return result.get("output", "No response generated.")
+    except Exception as e:
+        return f"Error processing request: {str(e)}"
+
+
+def smart_retrieve_and_generate(prompt: str, tenant=None) -> str:
+    """
+    Intelligently route the prompt to either:
+    1. Drug interaction checker (if it's a drug-related query)
+    2. Standard RAG pipeline (for general medical questions)
+    """
+    if is_drug_interaction_query(prompt):
+        drug_names = get_drug_names(prompt)
+        if len(drug_names) >= 2:
+            return process_with_tools(prompt)
+    
     state = {'question': prompt, 'context': None, 'answer': ''}
     if tenant:
         state.update({'tenant': tenant})

--- a/backend/app/core/config.py
+++ b/backend/app/core/config.py
@@ -72,6 +72,8 @@ class Settings(BaseSettings):
     QDRANT_COLLECTION_NAME: str
     QDRANT_API_KEY: str
     QDRANT_URL: str
+    ## OpenFDA
+    FDA_API_KEY: str = ""
 
 
 settings = Settings()  # type: ignore

--- a/backend/app/core/tools/__init__.py
+++ b/backend/app/core/tools/__init__.py
@@ -1,0 +1,11 @@
+from app.core.tools.drug_interaction import (
+    check_drug_interactions,
+    get_drug_info,
+    DRUG_TOOLS
+)
+
+__all__ = [
+    "check_drug_interactions",
+    "get_drug_info",
+    "DRUG_TOOLS"
+]

--- a/backend/app/core/tools/drug_interaction.py
+++ b/backend/app/core/tools/drug_interaction.py
@@ -1,0 +1,281 @@
+import requests
+from typing import List, Dict, Any, Optional
+from langchain_core.tools import tool
+from pydantic import BaseModel
+import os
+
+
+OPENFDA_API_KEY = os.getenv("FDA_API_KEY", "")
+
+BASE_URL = "https://api.fda.gov/drug/label.json"
+
+
+def _make_api_request(url: str, params: dict) -> Optional[dict]:
+    """Make request to OpenFDA API with optional API key."""
+    request_params = params.copy()
+    if OPENFDA_API_KEY:
+        request_params["api_key"] = OPENFDA_API_KEY
+    
+    try:
+        response = requests.get(url, params=request_params, timeout=30)
+        if response.status_code == 200:
+            return response.json()
+        return None
+    except requests.exceptions.RequestException:
+        return None
+
+
+def _get_drug_label(drug_name: str) -> List[Dict[str, Any]]:
+    """Get drug label information from OpenFDA."""
+    search_query = f'openfda.brand_name:"{drug_name}"+OR+openfda.generic_name:"{drug_name}"'
+    
+    params = {
+        "search": search_query,
+        "limit": 5,
+    }
+    
+    data = _make_api_request(BASE_URL, params)
+    if data and "results" in data:
+        return data["results"]
+    return []
+
+
+def _extract_relevant_sections(label: Dict[str, Any]) -> Dict[str, Any]:
+    """Extract relevant interaction-related sections from drug label."""
+    sections = {}
+    
+    relevant_fields = [
+        ("drug_interactions", "Drug Interactions"),
+        ("contraindications", "Contraindications"),
+        ("warnings", "Warnings"),
+        ("precautions", "Precautions"),
+        ("boxed_warning", "Boxed Warning"),
+        ("adverse_reactions", "Adverse Reactions"),
+        ("use_in_specific_populations", "Use in Specific Populations"),
+    ]
+    
+    for field, display_name in relevant_fields:
+        if field in label and label[field]:
+            sections[display_name] = label[field]
+    
+    return sections
+
+
+def _check_keyword_interactions(drug1_info: Dict[str, Any], drug2_info: Dict[str, Any]) -> List[Dict[str, Any]]:
+    """Check for keyword-based interaction warnings between two drugs."""
+    interactions = []
+    
+    drug1_name = drug1_info.get("name", "").lower()
+    drug2_name = drug2_info.get("name", "").lower()
+    
+    for section_name, content in drug1_info.get("sections", {}).items():
+        if isinstance(content, list):
+            content_text = " ".join(str(c) for c in content)
+        else:
+            content_text = str(content)
+        
+        content_lower = content_text.lower()
+        
+        if drug2_name in content_lower:
+            interactions.append({
+                "drugs": [drug1_info["name"], drug2_name.title()],
+                "section": section_name,
+                "description": content_text[:500],
+                "severity": _assess_severity(section_name, content_text)
+            })
+    
+    return interactions
+
+
+def _assess_severity(section: str, content: str) -> str:
+    """Assess the severity based on the section type."""
+    content_lower = content.lower()
+    
+    high_severity_keywords = ["serious", "severe", "life-threatening", "death", "fatal", "major"]
+    medium_severity_keywords = ["moderate", "increased", "may increase", "could increase"]
+    
+    if "boxed warning" in section.lower() or "contraindications" in section.lower():
+        return "HIGH - Contraindicated"
+    
+    if any(kw in content_lower for kw in high_severity_keywords):
+        return "HIGH"
+    elif any(kw in content_lower for kw in medium_severity_keywords):
+        return "MODERATE"
+    
+    return "LOW"
+
+
+@tool
+def check_drug_interactions(drugs: List[str]) -> str:
+    """
+    Check for interactions between multiple medications using the OpenFDA Drug Label API.
+    
+    Use this tool when a user asks about drug interactions, combining medications,
+    or safety of taking multiple drugs together.
+    
+    Args:
+        drugs: List of drug names to check for interactions (e.g., ["Aspirin", "Warfarin"])
+    
+    Returns:
+        A formatted string describing any interactions found between the drugs.
+    """
+    if not drugs or len(drugs) < 2:
+        return "Please provide at least two drugs to check for interactions."
+    
+    results = []
+    results.append(f"Drug Interaction Check for: {', '.join(drugs)}")
+    results.append("=" * 60)
+    results.append("Source: FDA Drug Labeling Database (openFDA)")
+    results.append("")
+    
+    drug_labels = {}
+    
+    for drug in drugs:
+        labels = _get_drug_label(drug)
+        if labels:
+            drug_labels[drug] = {
+                "name": drug,
+                "labels": labels,
+                "sections": _extract_relevant_sections(labels[0])
+            }
+        else:
+            drug_labels[drug] = {
+                "name": drug,
+                "labels": [],
+                "sections": {}
+            }
+    
+    all_interactions = []
+    
+    for i, drug1 in enumerate(drugs):
+        for drug2 in drugs[i+1:]:
+            if drug_labels[drug1]["sections"] or drug_labels[drug2]["sections"]:
+                interactions = _check_keyword_interactions(
+                    drug_labels[drug1],
+                    drug_labels[drug2]
+                )
+                all_interactions.extend(interactions)
+                
+                reverse_interactions = _check_keyword_interactions(
+                    drug_labels[drug2],
+                    drug_labels[drug1]
+                )
+                all_interactions.extend(reverse_interactions)
+    
+    if all_interactions:
+        results.append(f"\n⚠️  Found {len(all_interactions)} potential interaction(s):\n")
+        
+        seen = set()
+        for interaction in all_interactions:
+            key = (interaction["drugs"][0].lower(), interaction["drugs"][1].lower(), interaction["section"])
+            if key in seen:
+                continue
+            seen.add(key)
+            
+            results.append(f"Drugs: {' + '.join(interaction['drugs'])}")
+            results.append(f"Section: {interaction['section']}")
+            results.append(f"Severity: {interaction['severity']}")
+            
+            desc = interaction["description"]
+            if len(desc) > 300:
+                desc = desc[:300] + "..."
+            results.append(f"Details: {desc}")
+            results.append("-" * 50)
+    else:
+        results.append("\nNo specific interactions found in FDA labeling.")
+        results.append("\nNote: Always consult a healthcare provider for medication safety.")
+    
+    results.append("\n" + "=" * 60)
+    results.append("DISCLAIMER: This information is from FDA labeling and may not be")
+    results.append("comprehensive. Consult a healthcare professional before combining medications.")
+    
+    return "\n".join(results)
+
+
+@tool
+def get_drug_info(drug_name: str) -> str:
+    """
+    Get detailed information about a single drug using the OpenFDA Drug Label API.
+    
+    Use this tool when a user asks for information about a specific medication,
+    such as what a drug is used for, its side effects, or general details.
+    
+    Args:
+        drug_name: The name of the drug (e.g., "Aspirin", "Warfarin")
+    
+    Returns:
+        Formatted information about the drug.
+    """
+    if not drug_name:
+        return "Please provide a drug name."
+    
+    labels = _get_drug_label(drug_name)
+    
+    if not labels:
+        return f"No FDA labeling information found for: {drug_name}"
+    
+    results = []
+    results.append(f"Drug Information: {drug_name}")
+    results.append("=" * 50)
+    results.append("Source: FDA Drug Labeling Database (openFDA)")
+    results.append("")
+    
+    for i, label in enumerate(labels[:3]):
+        if i > 0:
+            results.append("-" * 30)
+        
+        openfda = label.get("openfda", {})
+        
+        if openfda.get("brand_name"):
+            results.append(f"Brand Name(s): {', '.join(openfda['brand_name'][:5])}")
+        
+        if openfda.get("generic_name"):
+            results.append(f"Generic Name(s): {', '.join(openfda['generic_name'][:5])}")
+        
+        if openfda.get("manufacturer_name"):
+            results.append(f"Manufacturer: {openfda['manufacturer_name'][0]}")
+        
+        if openfda.get("product_type"):
+            results.append(f"Product Type: {', '.join(openfda['product_type'][:3])}")
+        
+        sections = _extract_relevant_sections(label)
+        
+        if sections:
+            results.append("")
+            results.append("Key Label Information:")
+            
+            if "Indications and Usage" in sections:
+                usage = sections["Indications and Usage"]
+                if isinstance(usage, list) and usage:
+                    results.append(f"  Uses: {usage[0][:300]}...")
+            
+            if "Drug Interactions" in sections:
+                interactions = sections["Drug Interactions"]
+                if isinstance(interactions, list) and interactions:
+                    results.append(f"  Drug Interactions: {interactions[0][:300]}...")
+            
+            if "Contraindications" in sections:
+                contraindications = sections["Contraindications"]
+                if isinstance(contraindications, list) and contraindications:
+                    results.append(f"  Contraindications: {contraindications[0][:300]}...")
+            
+            if "Warnings" in sections:
+                warnings = sections["Warnings"]
+                if isinstance(warnings, list) and warnings:
+                    results.append(f"  Warnings: {warnings[0][:300]}...")
+            
+            if "Adverse Reactions" in sections:
+                adverse = sections["Adverse Reactions"]
+                if isinstance(adverse, list) and adverse:
+                    results.append(f"  Side Effects: {adverse[0][:300]}...")
+        
+        results.append("")
+    
+    results.append("=" * 50)
+    results.append("DISCLAIMER: This is FDA labeling information. Consult a healthcare")
+    results.append("professional for medical advice.")
+    
+    return "\n".join(results)
+
+
+DRUG_TOOLS = [check_drug_interactions, get_drug_info]

--- a/backend/app/views/chat.py
+++ b/backend/app/views/chat.py
@@ -8,7 +8,7 @@ from langchain_core.messages import BaseMessageChunk, message_to_dict
 
 from app.core.bot import (
     retrieve_and_generate, generate_chunks, generate_text_chunks, 
-    SYSTEM_PROMPT, retrieve_and_generate_sync
+    SYSTEM_PROMPT, retrieve_and_generate_sync, smart_retrieve_and_generate
 )
 from app.models.bot import UserQuery
 
@@ -53,6 +53,17 @@ async def retrieval_augmented_generation(query: UserQuery) -> Any:
     message = retrieve_and_generate_sync(prompt=query.prompt)
 
     return JSONResponse(status_code=status.HTTP_200_OK, content=message.content)
+
+
+@router.post("/rag/smart", response_model=Any)
+async def smart_rag(query: UserQuery) -> Any:
+    """
+    RAG with drug interaction tool-calling.
+    Automatically detects drug-related queries and uses the interaction checker.
+    """
+    result = smart_retrieve_and_generate(prompt=query.prompt)
+
+    return JSONResponse(status_code=status.HTTP_200_OK, content={"answer": result})
 
 
 @router.websocket("/rag/ws")

--- a/backend/poetry.lock
+++ b/backend/poetry.lock
@@ -1984,18 +1984,18 @@ xai = ["langchain-xai"]
 
 [[package]]
 name = "langchain-classic"
-version = "1.0.1"
+version = "1.0.2"
 description = "Building applications with LLMs through composability"
 optional = false
 python-versions = "<4.0.0,>=3.10.0"
 groups = ["main"]
 files = [
-    {file = "langchain_classic-1.0.1-py3-none-any.whl", hash = "sha256:131d83a02bb80044c68fedc1ab4ae885d5b8f8c2c742d8ab9e7534ad9cda8e80"},
-    {file = "langchain_classic-1.0.1.tar.gz", hash = "sha256:40a499684df36b005a1213735dc7f8dca8f5eb67978d6ec763e7a49780864fdc"},
+    {file = "langchain_classic-1.0.2-py3-none-any.whl", hash = "sha256:ae3480f488d2cf778f75e59ce0316b336fe2bcd4f8828aeb1aef1e2f26987d7f"},
+    {file = "langchain_classic-1.0.2.tar.gz", hash = "sha256:bbf686613d0051905794f2646ecb6a79fa398db399750a4af039107d93054335"},
 ]
 
 [package.dependencies]
-langchain-core = ">=1.2.5,<2.0.0"
+langchain-core = ">=1.2.17,<2.0.0"
 langchain-text-splitters = ">=1.1.0,<2.0.0"
 langsmith = ">=0.1.17,<1.0.0"
 pydantic = ">=2.7.4,<3.0.0"
@@ -5510,4 +5510,4 @@ cffi = ["cffi (>=1.17,<2.0) ; platform_python_implementation != \"PyPy\" and pyt
 [metadata]
 lock-version = "2.1"
 python-versions = "3.12.10"
-content-hash = "b779ba6433c8de3917270f7be83d66052298b38e303ee56570fff96c1e95d726"
+content-hash = "7be607a0479a9f01d86d81b6965621ec550e372c23900e3903b28c3a5ac7a7eb"

--- a/backend/pyproject.toml
+++ b/backend/pyproject.toml
@@ -24,6 +24,7 @@ langchain-community = "^0.4.1"
 websockets = "^15.0.1"
 pytz = "^2025.1"
 mangum = "^0.19.0"
+langchain-classic = "^1.0.2"
 
 [tool.poetry.group.dev.dependencies]
 ipykernel = "^6.29.5"

--- a/backend/requirements.txt
+++ b/backend/requirements.txt
@@ -17,6 +17,7 @@ PyJWT
 python-dotenv
 pytz
 qdrant-client
+requests
 SQLAlchemy
 sqlmodel
 tiktoken

--- a/ragbot/src/pages/chat/chat.tsx
+++ b/ragbot/src/pages/chat/chat.tsx
@@ -134,29 +134,29 @@ export function Chat() {
     return response;
   }
 
-  async function getRAGSyncResponse(text: string) {
-    const API_URL_CHAT_RAG_SYNC = import.meta.env.VITE_PUBLIC_API_URL + "/api/v1/chat/rag/sync";
-    try {
-      const response = await fetch(API_URL_CHAT_RAG_SYNC, {
-        method: "POST",
-        headers: {
-          "Content-Type": "application/json",
-        },
-        body: JSON.stringify({
-          prompt: text
-        }),
-      })
-      if (!response.ok) {
-        throw new Error("Failed to fetch llm response");
-      }
-      const data = await response.json();
-      return data;
-    } catch (error) {
-      console.error("Error fetching llm response:", error);
-    } finally {
-      console.log("Fetched llm response");
-    }
-  }
+  // async function getRAGSyncResponse(text: string) {
+  //   const API_URL_CHAT_RAG_SYNC = import.meta.env.VITE_PUBLIC_API_URL + "/api/v1/chat/rag/sync";
+  //   try {
+  //     const response = await fetch(API_URL_CHAT_RAG_SYNC, {
+  //       method: "POST",
+  //       headers: {
+  //         "Content-Type": "application/json",
+  //       },
+  //       body: JSON.stringify({
+  //         prompt: text
+  //       }),
+  //     })
+  //     if (!response.ok) {
+  //       throw new Error("Failed to fetch llm response");
+  //     }
+  //     const data = await response.json();
+  //     return data;
+  //   } catch (error) {
+  //     console.error("Error fetching llm response:", error);
+  //   } finally {
+  //     console.log("Fetched llm response");
+  //   }
+  // }
 
   async function getRAGSmartResponse(text: string) {
     const API_URL_CHAT_RAG_SMART = import.meta.env.VITE_PUBLIC_API_URL + "/api/v1/chat/rag/smart";

--- a/ragbot/src/pages/chat/chat.tsx
+++ b/ragbot/src/pages/chat/chat.tsx
@@ -158,6 +158,30 @@ export function Chat() {
     }
   }
 
+  async function getRAGSmartResponse(text: string) {
+    const API_URL_CHAT_RAG_SMART = import.meta.env.VITE_PUBLIC_API_URL + "/api/v1/chat/rag/smart";
+    try {
+      const response = await fetch(API_URL_CHAT_RAG_SMART, {
+        method: "POST",
+        headers: {
+          "Content-Type": "application/json",
+        },
+        body: JSON.stringify({
+          prompt: text
+        }),
+      })
+      if (!response.ok) {
+        throw new Error("Failed to fetch llm response");
+      }
+      const data = await response.json();
+      return data;
+    } catch (error) {
+      console.error("Error fetching llm response:", error);
+    } finally {
+      console.log("Fetched llm response");
+    }
+  }
+
   async function handleSubmit(text?: string) {
     const messageText = text || question;
     setIsLoading(true);
@@ -187,7 +211,8 @@ export function Chat() {
       }
     }
     else {
-      const response = await getRAGSyncResponse(messageText);
+      // const response = await getRAGSyncResponse(messageText);
+      const response = await getRAGSmartResponse(messageText);
       if (response) {
         setIsLoading(false);
         appendToMessages(response, traceId);


### PR DESCRIPTION
Changes:
- Uses https://api.fda.gov/drug/label.json endpoint
- Searches by brand_name or generic_name
- Extracts sections: drug_interactions, contraindications, warnings, precautions, boxed_warning, adverse_reactions
- Cross-references between drugs to find interactions
- Added optional FDA_API_KEY to config (works without it but rate-limited)

Note: OpenFDA doesn't have a dedicated interactions endpoint, so the tool searches for one drug's name mentioned in another drug's interaction sections. For production use, you may want to integrate a dedicated interaction API like DrugBank or Micromedex.